### PR TITLE
Add homepage option

### DIFF
--- a/application/meetings.csv
+++ b/application/meetings.csv
@@ -10,4 +10,4 @@ Silverton Friends Church,https://silvertonfriends.podomatic.com/,Programmed,,,Au
 West Hill Friends Church,https://soundcloud.com/westhillsfriends,Programmed,https://westhillsfriends.org/,,Audio Podcast,,US,Oregon,Portland,English,0,0
 Woodbrooke Quaker Center,https://www.woodbrooke.org.uk/about/online-mfw/,Unprogrammed,,"Zoom, Adobe Connect",Video Chat,GMT,GB,,Birmingham,English,1,1
 Australia Yearly Meeting,https://www.quakersaustralia.info/online-meeting-worship,Unprogrammed,,Zoom,Video Chat,AET,AU,,,English,1,1
-Friends Meeting at Cambridge,https://www.facebook.com/story.php?story_fbid=3128117540532709&id=120846944593132&__tn__=%2As%2As-R,Unprogrammed,https://fmcquaker.org/,Zoom,Video Chat,EST,US,Massachusetts,Cambridge,English,1,0
+Friends Meeting at Cambridge,https://www.facebook.com/pg/fmcquaker/posts/,Unprogrammed,https://fmcquaker.org/,Zoom,Video Chat,EST,US,Massachusetts,Cambridge,English,1,0

--- a/application/meetings.csv
+++ b/application/meetings.csv
@@ -1,12 +1,13 @@
-NAME,LINK,WORSHIP_FORMAT,MEDIUM,MEDIUM_FORMAT,TIME_ZONE,COUNTRY,STATE_PROVINCE,CITY_TOWN,LANGUAGE,IS_LIVE,LOCALS_FOCUSED
-Ben Lomond Quaker Center,http://www.quakercenter.org/meeting-for-worship/,Unprogrammed,Chatzy,Text Chat,PST,US,California,Ben Lomond,English,1,0
-Cloud Quakers,https://www.facebook.com/Cloud-Quakers-592173357909712,Unprogrammed,Zoom,Video Chat,MT,US,,,English,1,0
-Deep River Friends Meeting,https://www.deepriverfriends.com/sermons-2/,Programmed,,Audio Podcast,,US,North Carolina,High Point,English,0,0
-Fresh Pond Monthly Meeting,http://freshpondquakers.org/how-to-log-into-our-virtual-zoom-meeting-for-worship/,Unprogrammed,Zoom,Video Chat,EST,US,Massachusetts,Cambridge,English,1,0
-Pacific Yearly Meeting,https://www.pacificyearlymeeting.org/2018/2018-events/invitation-to-a-weekly-online-worship/,Unprogrammed,Zoom,Video Chat,PST,US,California,San Rafael,English,1,0
-Pendle Hill,https://pendlehill.org/explore/worship/join-us-online-for-worship-in-the-barn/,Unprogrammed,Zoom,Video Chat,EST,US,Pennsylvania,Wallingford,English,1,0
-Quaker Universalist Fellowship,https://universalistfriends.org/about/global-meeting-for-worship-gmfw,Unprogrammed,Zoom,Video Chat,GMT,US,,,English,1,0
-Silverton Friends Church,https://silvertonfriends.podomatic.com/,Programmed,,Audio Podcast,,US,Oregon,Silverton,English,0,0
-West Hill Friends Church,https://soundcloud.com/westhillsfriends,Programmed,,Audio Podcast,,US,Oregon,Portland,English,0,0
-Woodbrooke Quaker Center,https://www.woodbrooke.org.uk/about/online-mfw/,Unprogrammed,"Zoom, Adobe Connect",Video Chat,GMT,GB,,Birmingham,English,1,0
-Australia Yearly Meeting,https://www.quakersaustralia.info/online-meeting-worship,Unprogrammed,Zoom,Video Chat,AET,AU,,,English,1,0
+NAME,LINK,WORSHIP_FORMAT,HOMEPAGE,MEDIUM,MEDIUM_FORMAT,TIME_ZONE,COUNTRY,STATE_PROVINCE,CITY_TOWN,LANGUAGE,IS_LIVE,LARGE_MEETING
+Ben Lomond Quaker Center,http://www.quakercenter.org/meeting-for-worship/,Unprogrammed,,Chatzy,Text Chat,PST,US,California,Ben Lomond,English,1,0
+Cloud Quakers,https://www.facebook.com/Cloud-Quakers-592173357909712,Unprogrammed,,Zoom,Video Chat,MT,US,,,English,1,0
+Deep River Friends Meeting,https://www.deepriverfriends.com/sermons-2/,Programmed,,,Audio Podcast,,US,North Carolina,High Point,English,0,0
+Fresh Pond Monthly Meeting,http://freshpondquakers.org/how-to-log-into-our-virtual-zoom-meeting-for-worship/,Unprogrammed,,Zoom,Video Chat,EST,US,Massachusetts,Cambridge,English,1,0
+Pacific Yearly Meeting,https://www.pacificyearlymeeting.org/2018/2018-events/invitation-to-a-weekly-online-worship/,Unprogrammed,,Zoom,Video Chat,PST,US,California,San Rafael,English,1,0
+Pendle Hill,https://pendlehill.org/explore/worship/join-us-online-for-worship-in-the-barn/,Unprogrammed,,Zoom,Video Chat,EST,US,Pennsylvania,Wallingford,English,1,0
+Quaker Universalist Fellowship,https://universalistfriends.org/about/global-meeting-for-worship-gmfw,Unprogrammed,,Zoom,Video Chat,GMT,US,,,English,1,0
+Silverton Friends Church,https://silvertonfriends.podomatic.com/,Programmed,,,Audio Podcast,,US,Oregon,Silverton,English,0,0
+West Hill Friends Church,https://soundcloud.com/westhillsfriends,Programmed,https://westhillsfriends.org/,,Audio Podcast,,US,Oregon,Portland,English,0,0
+Woodbrooke Quaker Center,https://www.woodbrooke.org.uk/about/online-mfw/,Unprogrammed,,"Zoom, Adobe Connect",Video Chat,GMT,GB,,Birmingham,English,1,1
+Australia Yearly Meeting,https://www.quakersaustralia.info/online-meeting-worship,Unprogrammed,,Zoom,Video Chat,AET,AU,,,English,1,1
+Friends Meeting at Cambridge,https://www.facebook.com/story.php?story_fbid=3128117540532709&id=120846944593132&__tn__=%2As%2As-R,Unprogrammed,https://fmcquaker.org/,Zoom,Video Chat,EST,US,Massachusetts,Cambridge,English,1,0

--- a/application/meetings.py
+++ b/application/meetings.py
@@ -23,6 +23,7 @@ class MeetingCollection:
                     state_province=row['STATE_PROVINCE'],
                     city_town=row['CITY_TOWN'],
                     link=row['LINK'],
+                    homepage=row['HOMEPAGE'],
                     worship_format=row['WORSHIP_FORMAT'],
                     medium=row['MEDIUM'],
                     medium_format=row['MEDIUM_FORMAT'].strip('"'),

--- a/application/templates/directory/meeting/entry.html
+++ b/application/templates/directory/meeting/entry.html
@@ -5,8 +5,15 @@
 
         {% if meeting.metadata['link'] %}
         <tr>
-            <th>Link</th>
+            <th>Online MfW Details</th>
             <td><a href="{{ meeting.metadata['link'] }}">{{ meeting.name }}'s Online Meetings</a></td>
+        </tr>
+        {% endif %}
+
+        {% if meeting.metadata['homepage'] %}
+        <tr>
+            <th>Meeting Homepage</th>
+            <td><a href="{{ meeting.metadata['link'] }}">{{ meeting.name }}'s Homepage</a></td>
         </tr>
         {% endif %}
 
@@ -39,7 +46,7 @@
 
         {% if meeting.metadata['medium_format'] %}
         <tr>
-            <th>Medium Format</th>
+            <th>Medium</th>
             <td>
                 {% if meeting.metadata['is_live'] %}
                     Live


### PR DESCRIPTION
Adds option to add a link to a meeting homepage. I am mainly using this for meetings that have a website, but keep their meeting info on a facebook post, or similar.

Also adds Friends Meeting at Cambridge.