### PR TITLE
Drop mention of pandemic for potential search engine issues

### DIFF
--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -9,7 +9,7 @@
 {% block main %}	
 	<h2>What is this?</h2>
 	<p>
-		Because of the current pandemic, many Quaker meetings have started meeting online instead of in person. This website exists to help Quakers find an online meeting to attend and spread the word about ones they may be holding.
+		A listing of online Quaker meetings to help Quakers find online meetings to attend and spread the word about ones they may be holding.
 	</p>
 	{% include 'jump_to_directory.html' %}
 


### PR DESCRIPTION
It's possible that mentioning the coronavirus pandemic is preventing the page from appearing in search results because it makes it look more spurious to search engines, so I'm removing it for the minute.